### PR TITLE
chore(workflow): change pull_request event to pull_request_target

### DIFF
--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -6,7 +6,7 @@
 # name: Dependabot auto-approve and auto-merge
 on:
   repository_dispatch:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:


### PR DESCRIPTION
## Overview

The Dependabot auto-approve and auto-merge workflow was not functioning as intended because it used the `pull_request` event trigger. Workflows triggered by `pull_request` on PRs opened by bots (such as Dependabot) run with read-only token permissions and cannot write back to the repository, so the approve and merge steps were silently failing.

This change switches the trigger to `pull_request_target`, which runs in the context of the base branch and is granted the write permissions declared in the workflow (`contents: write`, `pull-requests: write`). This allows the workflow to successfully approve and auto-merge Dependabot PRs once all required status checks and branch protection rules are satisfied.

No logic, merge conditions, or repository guard (`github.repository == 'AbsaOSS/living-doc-generator-pdf'`) were changed — only the event trigger.

## Release Notes
- Fixed Dependabot auto-approve and auto-merge workflow by switching the trigger from `pull_request` to `pull_request_target`, restoring write permissions needed to approve and merge PRs automatically.
