### PR TITLE
#107: Bring `README.md` to the documentation skeleton and re-sync `CONTRIBUTING.md`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,40 +9,53 @@
 * **Check if the feature has already been requested** by searching through our **[GitHub Issues](https://github.com/AbsaOSS/living-doc-generator-pdf/issues)**.
 * If the feature request doesn't exist, feel free to create a new one. Tag it with the **request** label.
 
-## **Contributing to Development**
+## AI-free Principle
 
-* Check _Issues_ logs for the desired feature or bug. Ensure that no one else is already working on it.
-  * If the feature/bug is not yet filed, please create a detailed issue first:
-    * **"Detail Your Idea or Issue"**
-* Fork the repository.
-* Begin coding. Feel free to ask questions and collaborate with us.
-  * **Set up pre-commit hooks** to automatically check code quality before commits:
-    ```shell
-    pip install pre-commit
-    pre-commit install
-    ```
-    This will run automatic checks (Black, Pylint, mypy, etc.) before each commit.
-  * Commit messages should reference the GitHub Issue and provide a concise description:
-    * **"#34 Implement Feature X"**
-  * Remember to include tests for your code.
-* Once done, push to your fork and submit a Pull Request to our `master` branch:
-  * Pull Request titles should begin with the GitHub Issue number:
-    * **"45 Implementing New Analytics Feature"**
-  * Ensure the Pull Request description clearly outlines your solution.
-  * Link your PR to the relevant _Issue_.
+This pipeline runs AI-free; contributions must keep every collect → normalize → generate step deterministic — no LLM call in that path.
 
-## Branch Naming (PID:H-1)
-Branches MUST start with one of the allowed prefixes: `feature/`, `fix/`, `docs/`, `chore/`
+## Contributing to Development
+
+* Check _Issues_ for the desired feature or bug and make sure no one else is already working on it. If it is not filed yet, create a detailed issue first.
+* Fork the repository and create a working branch off an issue (see **Branch Naming** below).
+* Write the code and include tests for it.
+* Commit messages should reference the GitHub Issue and give a concise description, e.g. `#34 - Implement Feature X`.
+* Push to your fork and open a Pull Request (see **PR Naming**, **PR Description**, and **Target Branches** below).
+
+## Branch Naming
+
+Branches have to start with one of the allowed prefixes — `feature/`, `fix/`, `docs/`, `chore/` — followed immediately by the issue number, then a kebab-case scope: `<prefix>/<issue>-<scope>`.
+
 Examples:
-- `feature/add-hierarchy-support`
-- `fix/567-handle-empty-chapter`
-- `docs/improve-contribution-guide`
-- `chore/update-ci-python-version`
-Rename if needed before pushing:
+- `feature/542-add-hierarchy-support`
+- `fix/567-handle-empty-response`
+- `docs/203-contributing-rework`
+- `chore/318-update-ci-python-version`
+
+Use lowercase kebab-case and reflect the actual scope. The `check-pr-requirements` CI check rejects a branch that has no issue number.
+
+Rename before pushing if needed:
 ```shell
-git branch -m fix/<new-name>
+git branch -m <prefix>/<issue>-<new-scope>
 ```
-Use lowercase kebab-case and reflect actual scope.
+
+## PR Naming
+
+PR titles have to carry the related issue number, using one of these formats: `#123: Title` or `123 - Title`.
+
+Examples:
+- `#567: Handle empty response`
+- `203 - Rework contribution guide`
+
+## PR Description
+
+The PR body has to include these sections: `## Overview`, `## Release Notes`, `## Related`.
+- **Overview** – what changed and why.
+- **Release Notes** – short, user-facing summary for the changelog.
+- **Related** – link the issue with a closing keyword, e.g. `Closes #123` or `Fixes AB#12345`.
+
+## Target Branches
+
+PRs have to target `main`, `master`, `support/*`, or `release/*`.
 
 ### Community and Communication
 

--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ A source-agnostic GitHub Action that renders **any** structured JSON into a prof
 
 ## Overview
 
+> **Expected usage: GitHub Actions first.** The supported way to run this action is as a step in a GitHub Actions workflow, chained with the other `living-doc-*` actions. Running it locally — the `run_script.sh` / `python3 main.py` pattern documented in `DEVELOPER.md` — is a development and debugging affordance only, not a second supported deployment target.
+
+> **The Living Documentation pipeline runs AI-free.** Every step — collect → normalize → generate — is deterministic tooling (Python, JSON Schema validation, Jinja2/Markdown templates) with no LLM call anywhere in that path. [`AbsaOSS/agentic-toolkit`](https://github.com/AbsaOSS/agentic-toolkit) can accelerate the upstream *authoring* of GitHub Issues and `.feature` files, but it is never a runtime dependency of this pipeline: a human writing the same input by hand is a fully supported, identical path.
+
 The action is a generic JSON-to-PDF engine: you provide a JSON source file and either a built-in `document-type` or your own `template-path`. The raw JSON is passed to the templates unchanged as `data`, alongside injected `meta` (title, timestamp, source file name).
 
 **Built-in document types**
@@ -25,7 +29,25 @@ The action is a generic JSON-to-PDF engine: you provide a JSON source file and e
 - 🔍 Debug mode: save the intermediate HTML for troubleshooting
 - 📊 Reporting: emits `pdf_report.json` with statistics
 
-## Quick Start
+## Usage
+
+### Prerequisites
+
+- **Python 3.10 or later.**
+- **System dependencies** (WeasyPrint): `libpango-1.0-0`, `libpangocairo-1.0-0`, `libgdk-pixbuf2.0-0`, `libffi-dev`, `libcairo2`. These are installed automatically by the action on Ubuntu runners.
+
+### Adding the Action to Your Workflow
+
+```yaml
+- name: Generate PDF
+  uses: AbsaOSS/living-doc-generator-pdf@v1
+  with:
+    source-path: 'doc-source.json'
+    document-type: 'user-stories'
+    output-path: 'documentation.pdf'
+```
+
+#### Full Example of Action Step Definition
 
 ```yaml
 # .github/workflows/generate-docs.yml
@@ -47,6 +69,10 @@ jobs:
           source-path: 'doc-source.json'
           document-type: 'user-stories'
           output-path: 'documentation.pdf'
+          document-title: 'Product Backlog'
+          schema-path: 'generator/schemas/doc-issues-v1.0.0-schema.json'
+          debug-html: 'true'
+          verbose: 'true'
 
       - name: Upload PDF
         uses: actions/upload-artifact@v4
@@ -55,12 +81,11 @@ jobs:
           path: documentation.pdf
 ```
 
-## Requirements
+## Action Configuration
 
-- **Python:** 3.14 or later
-- **System dependencies** (WeasyPrint): `libpango-1.0-0`, `libpangocairo-1.0-0`, `libgdk-pixbuf2.0-0`, `libffi-dev`, `libcairo2`. These are installed automatically by the action on Ubuntu runners.
+### Environment Variables
 
-## Configuration
+None. All configuration is passed through the `with:` inputs below.
 
 ### Inputs
 
@@ -76,9 +101,9 @@ jobs:
 | `verbose` | boolean | No | `false` | Enable verbose logging |
 | `pdf_ready_json` | string (path) | No | - | **Deprecated** alias for `source-path` |
 
-At least one of `document-type` or `template-path` must be provided. When neither `document-title` is set, the title is derived from the document type's default (e.g. "User Stories") or the source file name.
+At least one of `document-type` or `template-path` must be provided. When `document-title` is not set, the title is derived from the document type's default (e.g. "User Stories") or the source file name.
 
-### Outputs
+## Action Outputs
 
 | Output | Description |
 |--------|-------------|
@@ -97,7 +122,13 @@ At least one of `document-type` or `template-path` must be provided. When neithe
 | 4 | Rendering error (WeasyPrint) | `Rendering failed:` |
 | 5 | File I/O error (write failure) | `File I/O error:` |
 
-## Source JSON
+## Developer Guide
+
+For local setup, static analysis, testing, coverage, running the action locally, and the branch-naming convention, see [DEVELOPER.md](./DEVELOPER.md).
+
+## How-to
+
+### Source JSON
 
 The action does not transform the source JSON — it is exposed to templates as `data` exactly as parsed. Each built-in document type expects a particular shape; see [examples/](./examples/) for runnable samples:
 
@@ -105,7 +136,7 @@ The action does not transform the source JSON — it is exposed to templates as 
 - [examples/ui_tests.json](./examples/ui_tests.json) — `ui-test-catalog`
 - [examples/coverage_matrix.json](./examples/coverage_matrix.json) — `coverage-matrix`
 
-### Optional schema validation
+#### Optional schema validation
 
 Validation is opt-in. Pass `schema-path` to validate the source before rendering; omit it to render as-is. Built-in schemas live in [generator/schemas/](./generator/schemas/):
 
@@ -116,7 +147,7 @@ with:
   schema-path: 'generator/schemas/doc-issues-v1.0.0-schema.json'
 ```
 
-## Template customization
+### Template customization
 
 Templates always have a single entry point: `main.html.jinja`. They receive two variables:
 
@@ -139,7 +170,7 @@ Three override levels are supported:
 {% endfor %}
 ```
 
-### Custom Jinja filters
+#### Custom Jinja filters
 
 - `markdown(text)` — convert Markdown to HTML.
 - `format_datetime(value, fmt='%Y-%m-%d %H:%M')` — format an ISO 8601 timestamp.
@@ -148,7 +179,7 @@ Three override levels are supported:
 
 See the full [template override guide](./docs/template-override-guide.md) for copying a built-in set, overriding partials, and troubleshooting.
 
-## Troubleshooting
+### Troubleshooting
 
 **`Invalid input: File '...' not found`** — `source-path` points to a missing file; verify the path.
 
@@ -160,22 +191,14 @@ See the full [template override guide](./docs/template-override-guide.md) for co
 
 **`File I/O error: Permission denied`** — the output directory is not writable; change `output-path` or grant write permission.
 
-## Contributing
+## Contribution Guidelines
 
-Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md). For development guidelines, see [DEVELOPER.md](./DEVELOPER.md).
+Contributions are welcome. See [CONTRIBUTING.md](./CONTRIBUTING.md) for the bug-report, feature-request, branch-naming, and PR conventions. For development guidelines, see [DEVELOPER.md](./DEVELOPER.md).
 
-```bash
-git clone https://github.com/AbsaOSS/living-doc-generator-pdf.git
-cd living-doc-generator-pdf
-pip install -r requirements.txt
-pytest tests/
-```
-
-## License
+### License Information
 
 Licensed under the Apache License 2.0 — see [LICENSE](./LICENSE).
 
----
+### Contact or Support Information
 
-**Maintained by:** [ABSA Group Limited](https://github.com/AbsaOSS)
-**Documentation:** [spec.md](./spec.md) | [DEVELOPER.md](./DEVELOPER.md) | [Template override guide](./docs/template-override-guide.md)
+Maintained by [ABSA Group Limited](https://github.com/AbsaOSS). Open a [GitHub Issue](https://github.com/AbsaOSS/living-doc-generator-pdf/issues) for questions, bug reports, or feature requests.


### PR DESCRIPTION
## Overview

### `README.md`

- **Added the `## Developer Guide` section** — one line pointing at [`DEVELOPER.md`](./DEVELOPER.md), placed after `## Action Outputs` and before `## How-to` / the contribution section. The pointer was previously buried in a code block near the bottom.
- **Added both boilerplate paragraphs verbatim, at the top of `## Overview`:**
  - *Expected usage: GitHub Actions first* (architecture §2.1).
  - *The Living Documentation pipeline runs AI-free* (architecture §4) — absent before.
- **Fixed the Python version**: `## Requirements` "Python: **3.14** or later" → a single `### Prerequisites` line reading **`Python 3.10 or later`**, matching `pyproject.toml` `requires-python` and the `3.10 → 3.14` CI matrix.
- **Removed the dead `spec.md` footer link** (no such file). The footer is folded into `## Contribution Guidelines` → `### Contact or Support Information`.
- **Aligned the heading order** to the action-repo skeleton, keeping every piece of existing content:

  | Skeleton section | Source in the old README |
  |---|---|
  | `## Overview` | `## Overview` (+ the two boilerplate paragraphs) |
  | `## Usage` → `### Prerequisites` | `## Requirements` |
  | `## Usage` → `### Adding the Action to Your Workflow` | minimal step from `## Quick Start` |
  | `## Usage` → `#### Full Example of Action Step Definition` | full workflow from `## Quick Start` |
  | `## Action Configuration` → `### Environment Variables` | *new — states "None"* |
  | `## Action Configuration` → `### Inputs` | `## Configuration` → `### Inputs` |
  | `## Action Outputs` (+ `### Exit codes`) | `## Configuration` → `### Outputs` + `### Exit codes` |
  | `## Developer Guide` | *new* |
  | `## How-to` | `## Source JSON`, `## Template customization`, `## Troubleshooting` |
  | `## Contribution Guidelines` (+ `### License Information`, `### Contact or Support Information`) | `## Contributing`, `## License`, footer |

- **Kept the `source-agnostic JSON → PDF` framing** in the lead paragraph and `## Overview` — no change to what the action is described as doing.

### `CONTRIBUTING.md`

Re-synced to `collector-gh/CONTRIBUTING.md` (canonical source, `repo-conventions.md` §6) — byte-identical at the git-blob level except the Issues-URL org path (`AbsaOSS/living-doc-generator-pdf`). Concretely:

- Added the `## AI-free Principle` section.
- Removed the pre-commit-hook setup instructions.
- Replaced the `## Branch Naming (PID:H-1)` section: every example now carries an issue number and matches `<prefix>/<issue>-<scope>`, the rule `check-pr-requirements` actually enforces (the old `docs/improve-contribution-guide` / `chore/update-ci-python-version` examples would fail that check).
- Split the compressed PR guidance into explicit `## PR Naming`, `## PR Description`, and `## Target Branches` sections.
- Trimmed `## Contributing to Development` to a 5-bullet flow.

Section order: `# How to Contribute?` → `## Identifying and Reporting Bugs` → `## Proposing New Features` → `## AI-free Principle` → `## Contributing to Development` → `## Branch Naming` → `## PR Naming` → `## PR Description` → `## Target Branches` → `### Community and Communication` → `#### Thanks!`

## Release Notes

- Reworked `README.md` to the shared action-repo documentation skeleton: added a `## Developer Guide` pointer, the "GitHub Actions first" and "AI-free pipeline" boilerplate paragraphs, and aligned all section headings; corrected the stated Python floor to 3.10 and removed a dead `spec.md` link.
- Re-synced `CONTRIBUTING.md` to the ecosystem-canonical form: added the AI-free principle, dropped pre-commit setup, corrected the branch-naming rule and examples to require an issue number, and split PR guidance into `PR Naming` / `PR Description` / `Target Branches` sections.

## Related

Closes #107
